### PR TITLE
Add battery saving and explicit hardware disconnect on exit of application

### DIFF
--- a/WiiBalanceScale.cs
+++ b/WiiBalanceScale.cs
@@ -99,7 +99,7 @@ namespace WiiBalanceScale
             BoardTimer = new System.Windows.Forms.Timer();
             BoardTimer.Interval = 50;
             BoardTimer.Tick += new System.EventHandler(BoardTimer_Tick);
-            BoardTimer.Start();
+            BoardTimer.Start(); 
 
             Application.Run(f);
             Shutdown();
@@ -109,6 +109,20 @@ namespace WiiBalanceScale
         {
             if (BoardTimer != null) { BoardTimer.Stop(); BoardTimer = null; }
             if (cm != null) { cm.Cancel(); cm = null; }
+            
+            if (bb != null)
+            {
+                try
+                {
+                    // Turn off the blue LED and drop the connection
+                    bb.SetLEDs(0);
+                    bb.Disconnect();
+                }
+                catch 
+                { 
+                }
+            }
+
             if (f != null) { if (f.Visible) f.Close(); f = null; }
         }
 
@@ -146,7 +160,6 @@ namespace WiiBalanceScale
             for (int i = 0; i < History.Length; i++)
                 History[i] = (i > HistoryCursor ? float.MinValue : ZeroedWeight);
         }
-
         static void BoardTimer_Tick(object sender, System.EventArgs e)
         {
             if (cm != null)

--- a/WiiBalanceScale.csproj
+++ b/WiiBalanceScale.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>WiiBalanceScale</RootNamespace>
     <AssemblyName>WiiBalanceScale</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ApplicationIcon>WiiBalanceScale.ico</ApplicationIcon>
     <Install>false</Install>


### PR DESCRIPTION
This PR updates the Shutdown() sequence to explicitly clear the device LED and invoke bb.Disconnect().

Currently, closing the application leaves the Wii Balance Board in an active Bluetooth state with the LED illuminated, which continuously drains the battery until the hardware hits its internal safety timeout. Explicitly terminating the reporting mode forces the board's microcontroller to drop into its low-power sleep state immediately upon application exit - which is when it is needed.

Additionally, the project's target framework was updated in the .csproj file to allow compilation on modern .NET SDK environments without missing v3.5 reference assembly errors.